### PR TITLE
Stop inheriting from Exporter

### DIFF
--- a/lib/Pod/Usage.pm
+++ b/lib/Pod/Usage.pm
@@ -26,7 +26,7 @@ BEGIN {
     $Pod::Usage::Formatter ||= 'Pod::Text';
     eval "require $Pod::Usage::Formatter";
     die $@ if $@;
-    @ISA = ( $Pod::Usage::Formatter, 'Exporter' );
+    @ISA = ( $Pod::Usage::Formatter );
 }
 
 our $MAX_HEADING_LEVEL = 3;


### PR DESCRIPTION
As mentioned in #17, it is only necessary to do *either* `use Exporter 'import'` *or* some form of `push @ISA, 'Exporter'`. Doing both is redundant, and the former is preferred, so this patch takes the latter back out.