### PR TITLE
Fix pod2usage failure on GetOptions error

### DIFF
--- a/scripts/pod2usage.PL
+++ b/scripts/pod2usage.PL
@@ -168,10 +168,13 @@ my @opt_specs = (
 );
 
 ## Parse options
-GetOptions(\%options, @opt_specs)  ||  pod2usage(2);
+my $r = GetOptions(\%options, @opt_specs);
 $Pod::Usage::Formatter = $options{formatter} if $options{formatter};
 require Pod::Usage;
 Pod::Usage->import();
+if (!$r) {
+    pod2usage(2);
+}
 pod2usage(1)  if ($options{help});
 pod2usage(VERBOSE => 2)  if ($options{man});
 


### PR DESCRIPTION
Currently, if an error is detected while parsing the command line options (e. g. "pod2usage --does-not-exist"), pod2usage tries to call Pod::Usage's pod2usage() before that module is loaded.  This change saves the result of parsing the command line options, loads the module and then calls pod2usage() if needed.